### PR TITLE
Feature: Meal Planning (create, read, update) Backend Logic

### DIFF
--- a/src/controllers/mealPlanController.js
+++ b/src/controllers/mealPlanController.js
@@ -1,6 +1,9 @@
 import MealPlan from "../models/MealPlan.js";
 import { MEAL_TYPES } from "../constants/recipeFilters.js";
 import { Recipe } from "../models/Recipe.js";
+import axios from "axios";
+import { SPOONACULAR } from "../constants/apiEndpoints.js";
+import { ENV } from "../utils/envLoader.js";
 
 // POST /api/mealPlans
 export const createMealPlan = async (req, res) => {
@@ -97,7 +100,7 @@ export const getWeeklyMealPlan = async (req, res) => {
 
                             recipeName = response.data?.title ?? "Unknown Recipe";
                         } catch (apiErr) {
-                            console.warn(`Spoonacular fetch failed for ID ${recipeId}`);
+                            console.warn(`Spoonacular fetch failed for ID ${recipeId}. Error: ${apiErr}`);
                         }
                     }
                 }

--- a/src/controllers/mealPlanController.js
+++ b/src/controllers/mealPlanController.js
@@ -1,0 +1,119 @@
+import MealPlan from "../models/MealPlan.js";
+import { MEAL_TYPES } from "../constants/recipeFilters.js";
+import { Recipe } from "../models/Recipe.js";
+
+// POST /api/mealPlans
+export const createMealPlan = async (req, res) => {
+    try {
+        const { userId, recipeId, date, mealType } = req.body;
+
+        if (!userId || !recipeId || !date || !mealType) {
+            return res.status(400).json({ message: "Missing required fields." });
+        }
+
+        if (!MEAL_TYPES.includes(mealType)) {
+            return res.status(400).json({ message: "Invalid meal type." });
+        }
+
+        const inputDate = new Date(date);
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
+        if (inputDate < today) {
+            return res.status(400).json({ message: "Cannot modify past meals." });
+        }
+
+        let mealPlan = await MealPlan.findOne({ userId });
+
+        if (!mealPlan) {
+            mealPlan = new MealPlan({ userId, meals: [] });
+        }
+
+        const existingMealIndex = mealPlan.meals.findIndex(
+            (meal) => meal.mealType === mealType && new Date(meal.date).toDateString() === inputDate.toDateString()
+        );
+
+        if (existingMealIndex !== -1) {
+            mealPlan.meals[existingMealIndex].recipeId = recipeId;
+        } else {
+            mealPlan.meals.push({ recipeId, mealType, date: inputDate });
+        }
+
+        await mealPlan.save();
+        res.status(200).json({ message: "Meal saved successfully.", mealPlan });
+    } catch (err) {
+        console.error("Error creating meal plan:", err);
+        res.status(500).json({ message: "Server error." });
+    }
+};
+
+// GET /api/mealPlans/week
+export const getWeeklyMealPlan = async (req, res) => {
+    try {
+        const { userId, start } = req.query;
+
+        if (!userId || !start) {
+            return res.status(400).json({ message: "Missing userId or start date." });
+        }
+
+        const startDate = new Date(start);
+        startDate.setHours(0, 0, 0, 0);
+
+        const weekDays = Array.from({ length: 7 }, (_, i) => {
+            const d = new Date(startDate);
+            d.setDate(d.getDate() + i);
+            d.setHours(0, 0, 0, 0);
+            return d;
+        });
+
+        const mealPlan = await MealPlan.findOne({ userId });
+
+        const weekMeals = [];
+
+        for (const date of weekDays) {
+            for (const mealType of MEAL_TYPES) {
+                const meal =
+                    mealPlan?.meals.find(
+                        (m) => m.mealType === mealType && new Date(m.date).toDateString() === date.toDateString()
+                    ) || null;
+
+                let recipeId = meal?.recipeId ?? null;
+                let recipeName = null;
+                let localRecipe = null;
+
+                if (recipeId) {
+                    localRecipe = await Recipe.findOne({ id: Number(recipeId) }).lean(); // Spoonacular ID
+
+                    if (localRecipe?.title) {
+                        recipeName = localRecipe.title;
+                    } else {
+                        // If not in DB, try Spoonacular
+                        try {
+                            const response = await axios.get(SPOONACULAR.RECIPE_INFORMATION(recipeId), {
+                                params: {
+                                    apiKey: ENV.SPOONACULAR_KEY,
+                                },
+                            });
+
+                            recipeName = response.data?.title ?? "Unknown Recipe";
+                        } catch (apiErr) {
+                            console.warn(`Spoonacular fetch failed for ID ${recipeId}`);
+                        }
+                    }
+                }
+
+                weekMeals.push({
+                    date,
+                    mealType,
+                    recipeId,
+                    recipeName,
+                });
+            }
+        }
+
+        res.status(200).json({ weekMeals });
+    } catch (err) {
+        console.error("Error getting weekly meal plan:", err);
+        res.status(500).json({ message: "Server error." });
+    }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { ENV } from "./utils/envLoader.js";
 import authRoutes from "./routes/authRoutes.js";
 import homeRoutes from "./routes/homeRoutes.js";
 import recipeRoutes from "./routes/recipeRoutes.js";
+import mealPlanRoutes from "./routes/mealPlanRoutes.js";
 
 import { logger } from "./utils/logger.js";
 
@@ -36,7 +37,8 @@ app.set("views", path.join(__dirname, "../views"));
 
 app.use("/auth", authRoutes);
 app.use("/", homeRoutes);
-app.use("/api", recipeRoutes);
+app.use("/api/recipes", recipeRoutes);
+app.use("/api/mealPlan", mealPlanRoutes);
 
 // Start server
 app.listen(ENV.PORT, () => {

--- a/src/models/MealPlan.js
+++ b/src/models/MealPlan.js
@@ -1,0 +1,32 @@
+import mongoose from "mongoose";
+import { MEAL_TYPES } from "../constants/recipeFilters.js";
+
+const MealEntrySchema = new mongoose.Schema({
+    recipeId: {
+        type: String,
+        default: null,
+    },
+    mealType: {
+        type: String,
+        enum: MEAL_TYPES,
+        required: true,
+    },
+    date: {
+        type: Date,
+        required: true,
+    },
+});
+
+const MealPlanSchema = new mongoose.Schema(
+    {
+        userId: {
+            type: mongoose.Schema.Types.ObjectId,
+            required: true,
+            ref: "User",
+        },
+        meals: [MealEntrySchema],
+    },
+    { timestamps: true }
+);
+
+export default mongoose.model("MealPlan", MealPlanSchema);

--- a/src/routes/mealPlanRoutes.js
+++ b/src/routes/mealPlanRoutes.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { createMealPlan, getWeeklyMealPlan } from "../controllers/mealPlanController.js";
+import { authenticateJWT } from "../middleware/authMiddleware.js";
+
+const router = express.Router();
+
+router.post("/", authenticateJWT, createMealPlan);
+router.get("/week", authenticateJWT, getWeeklyMealPlan);
+
+export default router;

--- a/src/routes/recipeRoutes.js
+++ b/src/routes/recipeRoutes.js
@@ -4,7 +4,7 @@ import { authenticateJWT } from "../middleware/authMiddleware.js";
 
 const router = express.Router();
 
-router.get("/recipes", authenticateJWT, getRecipes);
-router.get("/recipes/:id", authenticateJWT, getRecipeById);
+router.get("/", authenticateJWT, getRecipes);
+router.get("/:id", authenticateJWT, getRecipeById);
 
 export default router;


### PR DESCRIPTION
New APIs for meal planning: 

**- POST /api/mealPlans** 
Adds or updates a single meal (date + meal type) with a selected recipe.

**- GET /api/mealPlans/week?userId=&start=**
Returns the user’s meal plan for a given week. 
```
If a recipe is stored:
   Retrieves its title from the local database (Recipe collection)
Else: 
   Falls back to Spoonacular API if not found locally
```